### PR TITLE
use the latest transformers version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch==2.1.2
-transformers @ git+https://github.com/huggingface/transformers.git@ae49b218c3d718df90d8e4a109016450fb8f0632
+transformers>=4.38.1
 bitsandbytes>=0.41.1
 accelerate==0.27.2
 langchain==0.1.9


### PR DESCRIPTION
This change proposes to use the latest version of transformers, while maintaining the requirements found within the `ae49b218c3d718df90d8e4a109016450fb8f0632` commit that was merged into `4.38.1`.