### PR TITLE
add yfinance to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ flash-attn==2.5.5
 protobuf
 sentencepiece
 art
+yfinance


### PR DESCRIPTION
the default README [example](https://github.com/NousResearch/Hermes-Function-Calling/blob/84be5153d01ce000f29aadf6e55695e2f16ffa64/functions.py#L5) requires `yfinance` to be installed.