### PR TITLE
Add example of outlines + llama-cpp-python

### DIFF
--- a/examples/outlines_llama-cpp-python_Q_and_A_with_citations.ipynb
+++ b/examples/outlines_llama-cpp-python_Q_and_A_with_citations.ipynb
@@ -1,0 +1,863 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5c8a48bb-484c-4135-ad03-5380f4348070",
+   "metadata": {},
+   "source": [
+    "# Generate Synthetic Data and Q&A with Citations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52f5766f-a222-40d0-bb7b-87aea7f6acbb",
+   "metadata": {},
+   "source": [
+    "## Adapted from the Ollama notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aff56341-244e-475b-b0ca-63e41a59ef5f",
+   "metadata": {},
+   "source": [
+    "## Requirements"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "040befa2-f90d-480f-8c0e-9b2384b6e1ff",
+   "metadata": {},
+   "source": [
+    "### Install llama-cpp-python and outlines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "876492fb-569f-4034-9660-0c30191521dc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:14.112190Z",
+     "iopub.status.busy": "2024-07-13T17:57:14.111193Z",
+     "iopub.status.idle": "2024-07-13T17:57:14.117229Z",
+     "shell.execute_reply": "2024-07-13T17:57:14.115930Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:14.112138Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# RUN IT ONLY ONCE TO INSTALL THE REQUIREMENTS\n",
+    "# %pip install llama-cpp-python outlines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a633a79a-f12f-493a-b8e3-029a008a3610",
+   "metadata": {},
+   "source": [
+    "For detailed installation instructions, see [llama-cpp-python installation](https://llama-cpp-python.readthedocs.io/en/stable/) and [outlines installation](https://outlines-dev.github.io/outlines/installation/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa19089d-997d-41b9-9b1c-21f09ef03105",
+   "metadata": {},
+   "source": [
+    "### Pull the model from HuggingFace"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a2d88f6-39df-4dde-a206-48283d9f1b8d",
+   "metadata": {},
+   "source": [
+    "Download a GGUF model from HuggingFace [here](https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/tree/main), for example, the `Q4_K_M` one (it requires 4.92 GB):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9beb92f1-79d5-4ddd-9b3c-3b1723acd620",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:14.119085Z",
+     "iopub.status.busy": "2024-07-13T17:57:14.118657Z",
+     "iopub.status.idle": "2024-07-13T17:57:14.142574Z",
+     "shell.execute_reply": "2024-07-13T17:57:14.141425Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:14.119044Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# RUN IT ONLY ONCE TO DOWNLOAD THE GGUF MODEL, IN THIS CASE THE Q4_K_M\n",
+    "# !wget https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF/resolve/main/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00c1d29a-11f5-4e67-b968-1d7475ec105e",
+   "metadata": {},
+   "source": [
+    "## Usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e71b912b-5225-4257-87bb-1327d6a4e42a",
+   "metadata": {},
+   "source": [
+    "### Generate Synthetic Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e744906-879e-4a4b-90cc-1151dbdc6020",
+   "metadata": {},
+   "source": [
+    "#### Define Pydantic class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "26091031-2eaa-424c-9789-1f502d4697ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:14.144768Z",
+     "iopub.status.busy": "2024-07-13T17:57:14.144286Z",
+     "iopub.status.idle": "2024-07-13T17:57:14.246788Z",
+     "shell.execute_reply": "2024-07-13T17:57:14.245330Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:14.144722Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "class UserDetail(BaseModel):\n",
+    "    id: int = Field(..., description=\"Unique identifier\") # so the model keeps track of the number of fake users\n",
+    "    first_name: str\n",
+    "    last_name: str\n",
+    "    age: int"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fbc58b63-d071-4098-aa18-6c24115c3777",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:14.248435Z",
+     "iopub.status.busy": "2024-07-13T17:57:14.248075Z",
+     "iopub.status.idle": "2024-07-13T17:57:14.254668Z",
+     "shell.execute_reply": "2024-07-13T17:57:14.253769Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:14.248401Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from typing import List\n",
+    "\n",
+    "class Users(BaseModel):\n",
+    "    users: List[UserDetail]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc35fdaf-c980-41d8-9b08-25b3956fd3fa",
+   "metadata": {},
+   "source": [
+    "#### Load the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "16d810bb-9189-4af4-9734-1a031bca3cec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:14.256312Z",
+     "iopub.status.busy": "2024-07-13T17:57:14.255955Z",
+     "iopub.status.idle": "2024-07-13T17:57:19.851467Z",
+     "shell.execute_reply": "2024-07-13T17:57:19.850453Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:14.256282Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import llama_cpp\n",
+    "from llama_cpp import Llama\n",
+    "from outlines import generate, models\n",
+    "\n",
+    "llm = Llama(\n",
+    "    \"/home/asilva/models/Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf\", # replace with your /path/to/the/model\n",
+    "    n_gpu_layers=-1,\n",
+    "    tokenizer=llama_cpp.llama_tokenizer.LlamaHFTokenizer.from_pretrained(\n",
+    "        \"NousResearch/Hermes-2-Pro-Llama-3-8B\"\n",
+    "    ),\n",
+    "    use_mlock=True,\n",
+    "    flash_attn=True,\n",
+    "    verbose=False\n",
+    ")\n",
+    "model = models.LlamaCpp(llm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "25e4dac2-e2c4-4b80-89fa-b5c538660b28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:19.853544Z",
+     "iopub.status.busy": "2024-07-13T17:57:19.853186Z",
+     "iopub.status.idle": "2024-07-13T17:57:19.857034Z",
+     "shell.execute_reply": "2024-07-13T17:57:19.856308Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:19.853526Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", category=RuntimeWarning) # ignore runtime warnings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4c1ad604-ddd1-4dc1-a6cf-3c8a41a57553",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:19.857699Z",
+     "iopub.status.busy": "2024-07-13T17:57:19.857559Z",
+     "iopub.status.idle": "2024-07-13T17:57:22.652983Z",
+     "shell.execute_reply": "2024-07-13T17:57:22.652084Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:19.857686Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "generator = generate.json(model, Users)\n",
+    "response = generator(\"Create 5 fake users\", max_tokens=1024, temperature=0, seed=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8774e605-6b1a-4eb8-b20e-6bfdbecf27df",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:22.654065Z",
+     "iopub.status.busy": "2024-07-13T17:57:22.653871Z",
+     "iopub.status.idle": "2024-07-13T17:57:22.661043Z",
+     "shell.execute_reply": "2024-07-13T17:57:22.660505Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:22.654048Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[UserDetail(id=1, first_name='John', last_name='Doe', age=25),\n",
+       " UserDetail(id=2, first_name='Jane', last_name='Doe', age=30),\n",
+       " UserDetail(id=3, first_name='Bob', last_name='Smith', age=40),\n",
+       " UserDetail(id=4, first_name='Alice', last_name='Smith', age=35),\n",
+       " UserDetail(id=5, first_name='John', last_name='Smith', age=20)]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response.users"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "81d3e795-1d52-4b51-8010-0c9ca093d903",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:22.662139Z",
+     "iopub.status.busy": "2024-07-13T17:57:22.661708Z",
+     "iopub.status.idle": "2024-07-13T17:57:22.687663Z",
+     "shell.execute_reply": "2024-07-13T17:57:22.686377Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:22.662120Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "John\n",
+      "Doe\n",
+      "25\n",
+      "\n",
+      "Jane\n",
+      "Doe\n",
+      "30\n",
+      "\n",
+      "Bob\n",
+      "Smith\n",
+      "40\n",
+      "\n",
+      "Alice\n",
+      "Smith\n",
+      "35\n",
+      "\n",
+      "John\n",
+      "Smith\n",
+      "20\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for user in response.users:\n",
+    "    print(user.first_name)\n",
+    "    print(user.last_name)\n",
+    "    print(user.age)\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6caf5758-a047-45ca-b0ca-52e5173e8456",
+   "metadata": {},
+   "source": [
+    "### QA with Citations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb92a6ea-f10c-4c5d-b56b-08189fea42be",
+   "metadata": {},
+   "source": [
+    "#### Define Pydantic class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f743b0c2-5690-4c9b-82be-118044577d5c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:22.689614Z",
+     "iopub.status.busy": "2024-07-13T17:57:22.689161Z",
+     "iopub.status.idle": "2024-07-13T17:57:22.712493Z",
+     "shell.execute_reply": "2024-07-13T17:57:22.711490Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:22.689570Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'properties': {'question': {'title': 'Question', 'type': 'string'},\n",
+       "  'answer': {'title': 'Answer', 'type': 'string'},\n",
+       "  'citations': {'items': {'type': 'string'},\n",
+       "   'title': 'Citations',\n",
+       "   'type': 'array'}},\n",
+       " 'required': ['question', 'answer', 'citations'],\n",
+       " 'title': 'QuestionAnswer',\n",
+       " 'type': 'object'}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from typing import List\n",
+    "\n",
+    "from pydantic import BaseModel\n",
+    "\n",
+    "\n",
+    "class QuestionAnswer(BaseModel):\n",
+    "    question: str\n",
+    "    answer: str\n",
+    "    citations: List[str]\n",
+    "\n",
+    "schema = QuestionAnswer.model_json_schema()\n",
+    "schema"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9df7357d-6631-49d2-be43-b17bc0435e21",
+   "metadata": {},
+   "source": [
+    "#### Create function to generate final prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "746f0e22-a6a5-4925-9f97-19abde8c79ee",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:22.714215Z",
+     "iopub.status.busy": "2024-07-13T17:57:22.713820Z",
+     "iopub.status.idle": "2024-07-13T17:57:22.728386Z",
+     "shell.execute_reply": "2024-07-13T17:57:22.727263Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:22.714177Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def my_final_prompt(question, context):\n",
+    "    return (\n",
+    "        \"<|im_start|>system\\n\"\n",
+    "        \"You are a world class AI model who answers questions in JSON with correct and exact citations \"\n",
+    "        \"extracted from the `Context`. \"\n",
+    "        f\"Here's the json schema you must adhere to:\\n<schema>\\n{schema}\\n</schema><|im_end|>\\n\"\n",
+    "        \"<|im_start|>user\\n\"\n",
+    "        + \"`Context`: \"\n",
+    "        + context\n",
+    "        + \"\\n`Question`: \"\n",
+    "        + question + \"<|im_end|>\"\n",
+    "        + \"\\n<|im_start|>assistant\\n\"\n",
+    "        \"<schema>\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ec7caf8e-635a-4568-8a96-ecfda57addfb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:22.730390Z",
+     "iopub.status.busy": "2024-07-13T17:57:22.729934Z",
+     "iopub.status.idle": "2024-07-13T17:57:22.745117Z",
+     "shell.execute_reply": "2024-07-13T17:57:22.743828Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:22.730347Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "question = \"What did the author do during college?\"\n",
+    "context = \"\"\"\n",
+    "My name is Jason Liu, and I grew up in Toronto Canada but I was born in China.\n",
+    "I went to an arts high school but in university I studied Computational Mathematics and physics.\n",
+    "As part of coop I worked at many companies including Stitchfix, Facebook.\n",
+    "I also started the Data Science club at the University of Waterloo and I was the president of the club for 2 years.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "7324eb3c-bf00-42c9-80e8-171019bd14cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:22.747463Z",
+     "iopub.status.busy": "2024-07-13T17:57:22.746635Z",
+     "iopub.status.idle": "2024-07-13T17:57:22.769163Z",
+     "shell.execute_reply": "2024-07-13T17:57:22.767814Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:22.747414Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<|im_start|>system\n",
+      "You are a world class AI model who answers questions in JSON with correct and exact citations extracted from the `Context`. Here's the json schema you must adhere to:\n",
+      "<schema>\n",
+      "{'properties': {'question': {'title': 'Question', 'type': 'string'}, 'answer': {'title': 'Answer', 'type': 'string'}, 'citations': {'items': {'type': 'string'}, 'title': 'Citations', 'type': 'array'}}, 'required': ['question', 'answer', 'citations'], 'title': 'QuestionAnswer', 'type': 'object'}\n",
+      "</schema><|im_end|>\n",
+      "<|im_start|>user\n",
+      "`Context`: \n",
+      "My name is Jason Liu, and I grew up in Toronto Canada but I was born in China.\n",
+      "I went to an arts high school but in university I studied Computational Mathematics and physics.\n",
+      "As part of coop I worked at many companies including Stitchfix, Facebook.\n",
+      "I also started the Data Science club at the University of Waterloo and I was the president of the club for 2 years.\n",
+      "\n",
+      "`Question`: What did the author do during college?<|im_end|>\n",
+      "<|im_start|>assistant\n",
+      "<schema>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(my_final_prompt(question, context))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "9c87dbe9-e7f7-4496-a5fd-1df1d66e155b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:22.771242Z",
+     "iopub.status.busy": "2024-07-13T17:57:22.770727Z",
+     "iopub.status.idle": "2024-07-13T17:57:23.002395Z",
+     "shell.execute_reply": "2024-07-13T17:57:23.001084Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:22.771195Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from outlines import generate, models\n",
+    "\n",
+    "model = models.LlamaCpp(llm)\n",
+    "generator = generate.json(model, QuestionAnswer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e1a2de78-c638-4a42-a2f4-3ff25191cb5e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:23.003436Z",
+     "iopub.status.busy": "2024-07-13T17:57:23.003244Z",
+     "iopub.status.idle": "2024-07-13T17:57:26.021910Z",
+     "shell.execute_reply": "2024-07-13T17:57:26.021061Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:23.003420Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "answer = generator(my_final_prompt(context, question), max_tokens=1024, temperature=0, seed=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "ce7c29c8-2720-480c-a009-98713c9892a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:26.022960Z",
+     "iopub.status.busy": "2024-07-13T17:57:26.022769Z",
+     "iopub.status.idle": "2024-07-13T17:57:26.027693Z",
+     "shell.execute_reply": "2024-07-13T17:57:26.027020Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:26.022943Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "QuestionAnswer(question='What did Jason Liu do during college?', answer='During college, Jason Liu studied Computational Mathematics and Physics. He also worked at companies such as Stitchfix and Facebook, and started the Data Science club at the University of Waterloo, serving as its president for two years.', citations=['I went to an arts high school but in university I studied Computational Mathematics and physics.', 'As part of coop I worked at many companies including Stitchfix, Facebook.', 'I also started the Data Science club at the University of Waterloo and I was the president of the club for 2 years.'])"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "answer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "bd061544-76e4-4b0e-b06c-23775bccf1d2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:26.029655Z",
+     "iopub.status.busy": "2024-07-13T17:57:26.029019Z",
+     "iopub.status.idle": "2024-07-13T17:57:26.055293Z",
+     "shell.execute_reply": "2024-07-13T17:57:26.054042Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:26.029616Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "question1 = \"Where was John born?\"\n",
+    "context1 = \"\"\"\n",
+    "John Doe is a software engineer who was born in New York, USA. \n",
+    "He studied Computer Science at the Massachusetts Institute of Technology. \n",
+    "During his studies, he interned at Google and Microsoft. \n",
+    "He also founded the Artificial Intelligence club at his university and served as its president for three years.\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "question2 = \"What did Emily study in university?\"\n",
+    "context2 = \"\"\"\n",
+    "Emily Smith is a data scientist from London, England. \n",
+    "She attended the University of Cambridge where she studied Statistics and Machine Learning. \n",
+    "She interned at IBM and Amazon during her summer breaks. \n",
+    "Emily was also the head of the Women in Tech society at her university.\n",
+    "\"\"\"\n",
+    "\n",
+    "question3 = \"Which companies did Robert intern at?\"\n",
+    "context3 = \"\"\"\n",
+    "Robert Johnson, originally from Sydney, Australia, is a renowned cybersecurity expert. \n",
+    "He studied Information Systems at the University of Melbourne. \n",
+    "Robert interned at several cybersecurity firms including NortonLifeLock and McAfee. \n",
+    "He was also the leader of the Cybersecurity club at his university.\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "question4 = \"What club did Alice start at her university?\"\n",
+    "context4 = \"\"\"\n",
+    "Alice Williams, a native of Dublin, Ireland, is a successful web developer. \n",
+    "She studied Software Engineering at Trinity College Dublin. \n",
+    "Alice interned at several tech companies including Shopify and Squarespace. \n",
+    "She started the Web Development club at her university and was its president for two years.\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "question5 = \"What did Michael study in high school?\"\n",
+    "context5 = \"\"\"\n",
+    "Michael Brown is a game developer from Tokyo, Japan. \n",
+    "He attended a specialized high school where he studied Game Design. \n",
+    "He later attended the University of Tokyo where he studied Computer Science. \n",
+    "Michael interned at Sony and Nintendo during his university years. \n",
+    "He also started the Game Developers club at his university.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "71990857-0e45-4ef9-92c9-ad688ae2d9d5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-13T17:57:26.057195Z",
+     "iopub.status.busy": "2024-07-13T17:57:26.056750Z",
+     "iopub.status.idle": "2024-07-13T17:57:33.586142Z",
+     "shell.execute_reply": "2024-07-13T17:57:33.585021Z",
+     "shell.execute_reply.started": "2024-07-13T17:57:26.057152Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Where was John born?'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'John Doe was born in New York, USA.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['John Doe is a software engineer who was born in New York, USA.']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'What did Emily study in university?'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Emily studied Statistics and Machine Learning in university.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['She attended the University of Cambridge where she studied Statistics and Machine Learning.']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Which companies did Robert intern at?'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Robert interned at NortonLifeLock and McAfee.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['Robert Johnson, originally from Sydney, Australia, is a renowned cybersecurity expert. He interned at several cybersecurity firms including NortonLifeLock and McAfee.']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'What club did Alice start at her university?'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Alice started the Web Development club at her university.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['Alice Williams, a native of Dublin, Ireland, is a successful web developer. She started the Web Development club at her university and was its president for two years.']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'What did Michael study in high school?'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Michael studied Game Design in high school.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['Michael Brown is a game developer from Tokyo, Japan. He attended a specialized high school where he studied Game Design.']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for question, context in [\n",
+    "    (question1, context1),\n",
+    "    (question2, context2),\n",
+    "    (question3, context3),\n",
+    "    (question4, context4),\n",
+    "    (question5, context5),\n",
+    "]:\n",
+    "    final_prompt = my_final_prompt(question, context)\n",
+    "    generator = generate.json(model, QuestionAnswer)\n",
+    "    response = generator(final_prompt, max_tokens=1024, temperature=0, seed=42)\n",
+    "    display(question)\n",
+    "    display(response.answer)\n",
+    "    display(response.citations)\n",
+    "    print(\"\\n\\n\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Example of using [outlines](https://github.com/outlines-dev/outlines) + [llama-cpp-python](https://github.com/abetlen/llama-cpp-python) with [Hermes 2 Pro Llama 3 8B GGUF](https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B-GGUF) model by NousResearch. The example shows:
- how to generate synthetic data by following a Pydantic schema 
- how to answer questions by providing citations.

It is inspired by the notebook [instructor_ollama](https://github.com/NousResearch/Hermes-Function-Calling/blob/main/examples/instructor_ollama.ipynb)  which was not considered by the previous [llama-cpp-multiple-fn](https://github.com/NousResearch/Hermes-Function-Calling/blob/main/examples/lllama-cpp-multiple-fn.ipynb) notebook.